### PR TITLE
add incoming webhooks for DMs and channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,7 @@ python app.py Testing/NodeB.env
 ```
 
 Each node gets its own database and port as defined in its env file.
+
+## Webhooks
+
+See [WEBHOOKS.md](WEBHOOKS.md) for documentation on creating and using webhooks to send messages via external services.

--- a/WEBHOOKS.md
+++ b/WEBHOOKS.md
@@ -1,0 +1,99 @@
+# Webhooks
+
+Webhooks allow external services to send messages to BSCP as incoming DMs or channel messages. Each webhook has a unique URL that accepts incoming POST requests.
+
+## Creating a Webhook
+
+1. Open **Settings** in the app
+2. Scroll to **Webhooks** section
+3. Click **Create**
+4. Enter webhook name (e.g., "GitHub", "Alerts")
+5. Optionally add an avatar URL
+6. Click **Create**
+
+Your webhook is created with a unique URL displayed in the list.
+
+## Webhook URL Format
+
+```
+http://[domain]/webhooks/[webhook_id]/[webhook_token]
+```
+
+Example:
+```
+http://localhost:5000/webhooks/a1b2c3d4-e5f6-7890-abcd-ef1234567890/ghi3jklm_nopqrst_uvwxyz
+```
+
+## Sending Messages
+
+Send a POST request to your webhook URL with JSON payload:
+
+```bash
+curl -X POST http://localhost:5000/webhooks/[id]/[token] \
+  -H "Content-Type: application/json" \
+  -d '{
+    "content": "Your message here",
+    "username": "Custom Name (optional)",
+    "avatar_url": "https://example.com/avatar.png (optional)"
+  }'
+```
+
+## Payload Format
+
+**Required:**
+- `content` (string) - Message text, supports markdown
+
+**Optional:**
+- `username` (string) - Override webhook name for this message display
+- `avatar_url` (string) - Override webhook avatar for this message (currently not used)
+
+## Examples
+
+**Simple message:**
+```json
+{
+  "content": "Build completed successfully!"
+}
+```
+
+**With GitHub style:**
+```json
+{
+  "content": "**User123** pushed 3 commits to main\n- Fix bug in auth\n- Add tests\n- Update docs"
+}
+```
+
+**Markdown support:**
+```json
+{
+  "content": "**Bold text** *italic* `code` [link](https://example.com)"
+}
+```
+
+## Webhook Management
+
+- **Copy URL** - Copy webhook URL to clipboard
+- **Regenerate** - Create new token (old token stops working)
+- **Delete** - Permanently remove webhook
+
+Webhook names are immutable. Create a new webhook if you need a different name.
+
+## Channel Webhooks
+
+Channel servers also support webhooks with the same API:
+
+```bash
+curl -X POST http://[channel-domain]/webhooks/[id]/[token] \
+  -H "Content-Type: application/json" \
+  -d '{"content": "Message to channel"}'
+```
+
+Create channel webhooks via the channel server API:
+```bash
+POST /api/channel/webhooks
+{
+  "path": "domain#channel#subchannel",
+  "name": "Webhook Name",
+  "avatar_url": "https://example.com/avatar.png"
+}
+```

--- a/app.py
+++ b/app.py
@@ -258,6 +258,7 @@ class User(db.Model):
     # Relatie naar actieve apparaten/sessies
     sessions = db.relationship('UserSession', backref='user', lazy=True, cascade="all, delete-orphan")
     push_subscriptions = db.relationship('PushSubscription', backref='user', lazy=True, cascade="all, delete-orphan")
+    webhooks = db.relationship('Webhook', backref='user', lazy=True, cascade="all, delete-orphan")
 
 class UserSession(db.Model):
     id = db.Column(db.String(255), primary_key=True, default=lambda: str(uuid.uuid4()))
@@ -291,6 +292,16 @@ class InviteCode(db.Model):
     created_at = db.Column(db.DateTime, default=datetime.now)
     used_at = db.Column(db.DateTime)
     expires_at = db.Column(db.DateTime)
+
+class Webhook(db.Model):
+    id = db.Column(db.String(255), primary_key=True, default=lambda: str(uuid.uuid4()))
+    user_id = db.Column(db.String(255), db.ForeignKey('user.id'), nullable=False)
+    channel_id = db.Column(db.String(255))
+    name = db.Column(db.String(100), nullable=False)
+    token = db.Column(db.String(64), unique=True, nullable=False)
+    profile_pic = db.Column(db.Text)
+    created_at = db.Column(db.DateTime, default=datetime.now)
+    last_used = db.Column(db.DateTime)
 
 
 def send_push_notification(user, title, body, url='/'):
@@ -393,6 +404,66 @@ def media_proxy():
 def serve_upload(filename):
     return send_from_directory(app.config['UPLOAD_FOLDER'], filename)
 
+@app.route("/webhooks/<webhook_id>/<webhook_token>", methods=["POST"])
+def receive_webhook(webhook_id, webhook_token):
+    """Receive incoming webhook and send as DM"""
+    from schemas import WebhookPayload
+    from marshmallow import ValidationError
+
+    payload_schema = WebhookPayload()
+
+    # Parse and validate JSON
+    try:
+        data = request.get_json()
+        if not data:
+            return jsonify({"error": "Missing JSON body"}), 400
+        data = payload_schema.load(data)
+    except ValidationError as err:
+        return jsonify({"errors": err.messages}), 400
+    except Exception as err:
+        return jsonify({"error": str(err)}), 400
+
+    # Find webhook
+    webhook = db.session.query(Webhook).filter_by(id=webhook_id, token=webhook_token).first()
+    if not webhook:
+        return jsonify({"error": "Invalid webhook"}), 404
+
+    # Update last_used
+    webhook.last_used = datetime.now()
+    db.session.commit()
+
+    # Create message
+    msg_uuid = str(uuid.uuid4())
+    full_id = f"{DOMAIN}/{msg_uuid}"
+    val_key = "key-" + msg_uuid[:8]
+
+    sender = f"webhook-{webhook.id}@{DOMAIN}"
+
+    receiver = f"{webhook.user.username}@{DOMAIN}"
+
+    new_msg = Message(
+        id=full_id,
+        sender=sender,
+        receiver=receiver,
+        text=data["content"],
+        validation_key=val_key,
+    )
+    db.session.add(new_msg)
+    db.session.commit()
+
+    # Send push notification
+    send_push_notification(
+        webhook.user,
+        f"Message from {webhook.name}",
+        data["content"],
+        url='/',
+    )
+
+    return jsonify({
+        "success": True,
+        "message_id": full_id,
+    }), 201
+
 @app.route("/.well-known/BSCP/userserver")
 @app.route("/.well-known/BSCP/userserver.json")
 def serve_userserver_config():
@@ -418,6 +489,7 @@ def serve_userserver_config():
                 "auth_login": "/api/auth/login",
                 "auth_register": "/api/auth/register",
                 "auth_setup": "/api/auth/setup",
+                "webhooks": "/api/user/webhooks",
                 "federation_receive": "/federation/receive",
                 "federation_validate": "/federation/validate",
                 "media_proxy": "/media/proxy",
@@ -427,7 +499,8 @@ def serve_userserver_config():
             "federation": True,
             "channels": False,
             "direct_messaging": True,
-            "media_upload": True
+            "media_upload": True,
+            "webhooks": True
         }
     }
     return config, 200, {"Content-Type": "application/json; charset=utf-8"}

--- a/channelserver.py
+++ b/channelserver.py
@@ -1,4 +1,4 @@
-import os, sys, requests, os
+import os, sys, requests, os, uuid, secrets
 from flask import Flask, request, jsonify
 from flask_sqlalchemy import SQLAlchemy
 from datetime import datetime
@@ -27,6 +27,15 @@ class ChannelMessage(db.Model):
     sender = db.Column(db.String(100))
     text = db.Column(db.Text)
     timestamp = db.Column(db.DateTime, default=datetime.utcnow, index=True)
+
+class ChannelWebhook(db.Model):
+    id = db.Column(db.String(255), primary_key=True, default=lambda: str(uuid.uuid4()))
+    channel_path = db.Column(db.String(255), nullable=False)
+    name = db.Column(db.String(100), nullable=False)
+    token = db.Column(db.String(64), unique=True, nullable=False)
+    profile_pic = db.Column(db.Text)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    last_used = db.Column(db.DateTime)
 
 with app.app_context():
     db.create_all()
@@ -85,6 +94,111 @@ def poll_messages():
         "time": m.timestamp.timestamp()
     } for m in reversed(msgs)])
 
+@app.route("/api/channel/webhooks", methods=["GET"])
+def list_channel_webhooks():
+    """List webhooks for a channel"""
+    channel_path = request.args.get("path")
+    if not channel_path:
+        return jsonify({"error": "Missing channel path"}), 400
+
+    webhooks = ChannelWebhook.query.filter_by(channel_path=channel_path).all()
+    return jsonify([{
+        "id": w.id,
+        "name": w.name,
+        "url": f"http://{DOMAIN}/webhooks/{w.id}/{w.token}",
+        "profile_pic": w.profile_pic,
+        "created_at": w.created_at.timestamp(),
+        "last_used": w.last_used.timestamp() if w.last_used else None,
+    } for w in webhooks])
+
+
+@app.route("/api/channel/webhooks", methods=["POST"])
+def create_channel_webhook():
+    """Create a webhook for a channel. Name is immutable and used as message sender identity."""
+    data = request.json
+    channel_path = data.get("path")
+    name = data.get("name")
+
+    if not channel_path or not name:
+        return jsonify({"error": "Missing channel path or name"}), 400
+
+    webhook = ChannelWebhook(
+        channel_path=channel_path,
+        name=name,
+        token=secrets.token_urlsafe(32),
+        profile_pic=data.get("avatar_url"),
+    )
+    db.session.add(webhook)
+    db.session.commit()
+
+    return jsonify({
+        "id": webhook.id,
+        "name": webhook.name,
+        "url": f"http://{DOMAIN}/webhooks/{webhook.id}/{webhook.token}",
+        "profile_pic": webhook.profile_pic,
+        "created_at": webhook.created_at.timestamp(),
+    }), 201
+
+
+@app.route("/api/channel/webhooks/<webhook_id>", methods=["DELETE"])
+def delete_channel_webhook(webhook_id):
+    """Delete a channel webhook"""
+    webhook = ChannelWebhook.query.filter_by(id=webhook_id).first()
+    if not webhook:
+        return jsonify({"error": "Webhook not found"}), 404
+
+    db.session.delete(webhook)
+    db.session.commit()
+    return "", 204
+
+
+@app.route("/api/channel/webhooks/<webhook_id>/regenerate", methods=["POST"])
+def regenerate_channel_webhook(webhook_id):
+    """Regenerate a channel webhook token"""
+    webhook = ChannelWebhook.query.filter_by(id=webhook_id).first()
+    if not webhook:
+        return jsonify({"error": "Webhook not found"}), 404
+
+    webhook.token = secrets.token_urlsafe(32)
+    db.session.commit()
+
+    return jsonify({"url": f"http://{DOMAIN}/webhooks/{webhook.id}/{webhook.token}"}), 200
+
+
+@app.route("/webhooks/<webhook_id>/<webhook_token>", methods=["POST"])
+def receive_channel_webhook(webhook_id, webhook_token):
+    """Receive incoming webhook and send to channel"""
+    data = request.json
+    if not data or "content" not in data:
+        return jsonify({"error": "Missing content"}), 400
+
+    webhook = ChannelWebhook.query.filter_by(id=webhook_id, token=webhook_token).first()
+    if not webhook:
+        return jsonify({"error": "Invalid webhook"}), 404
+
+    webhook.last_used = datetime.utcnow()
+    db.session.commit()
+
+    msg_uuid = str(uuid.uuid4())
+    full_id = f"{DOMAIN}/message/{msg_uuid}"
+
+    sender = f"webhook-{webhook.id}@{DOMAIN}"
+
+    new_msg = ChannelMessage(
+        id=full_id,
+        channel_path=webhook.channel_path,
+        sender=sender,
+        text=data["content"],
+    )
+    db.session.add(new_msg)
+    db.session.commit()
+
+    return jsonify({
+        "success": True,
+        "message_id": full_id,
+    }), 201
+
+
 @app.route("/.well-known/BSCP/channelserver")
 def serve_channelserver_config():
     """Serve BSCP channelserver configuration in JSON format"""
@@ -98,14 +212,16 @@ def serve_channelserver_config():
             "base": f"http://{DOMAIN}",
             "endpoints": {
                 "channel_send": "/api/channel/send",
-                "channel_poll": "/api/channel/poll"
+                "channel_poll": "/api/channel/poll",
+                "channel_webhooks": "/api/channel/webhooks"
             }
         },
         "capabilities": {
             "federation": True,
             "channels": True,
             "direct_messaging": False,
-            "media_upload": False
+            "media_upload": False,
+            "webhooks": True
         }
     }
     

--- a/frontend/src/components/chat/MessageBubble.tsx
+++ b/frontend/src/components/chat/MessageBubble.tsx
@@ -9,6 +9,7 @@ interface MessageBubbleProps {
   isPending: boolean;
   isFailed: boolean;
   profilePic?: string;
+  displayName?: string;
 }
 
 /** Convert bare image/video URLs into markdown/HTML */
@@ -48,6 +49,7 @@ const MessageBubble: FC<MessageBubbleProps> = ({
   isPending,
   isFailed,
   profilePic,
+  displayName,
 }) => {
   const renderedHtml = renderMarkdown(message.text);
 
@@ -64,6 +66,8 @@ const MessageBubble: FC<MessageBubbleProps> = ({
       ? 'Failed'
       : formatTime(message.timestamp);
 
+  const senderName = displayName || message.sender.split('@')[0];
+
   return (
     <div
       className={`flex gap-2.5 ${isOwn ? 'flex-row-reverse' : 'flex-row'} ${
@@ -76,7 +80,7 @@ const MessageBubble: FC<MessageBubbleProps> = ({
       />
 
       <div className={`flex max-w-[70%] flex-col ${isOwn ? 'items-end' : 'items-start'}`}>
-        <span className="mb-1 text-xs text-[#71747a]">{message.sender}</span>
+        <span className="mb-1 text-xs text-[#71747a]">{senderName}</span>
 
         <div
           className={`msg-content rounded-2xl px-4 py-2.5 text-sm leading-relaxed ${

--- a/frontend/src/components/chat/MessageInput.tsx
+++ b/frontend/src/components/chat/MessageInput.tsx
@@ -4,11 +4,14 @@ interface MessageInputProps {
   onSend: (text: string) => void;
   onFileUpload: (file: File) => void;
   disabled?: boolean;
+  isWebhook?: boolean;
 }
 
-const MessageInput: FC<MessageInputProps> = ({ onSend, onFileUpload, disabled }) => {
+const MessageInput: FC<MessageInputProps> = ({ onSend, onFileUpload, disabled, isWebhook }) => {
   const [text, setText] = useState('');
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const placeholder = isWebhook ? 'Cannot send messages to webhooks :)' : 'Type a message...';
 
   const handleSend = () => {
     const trimmed = text.trim();
@@ -59,7 +62,7 @@ const MessageInput: FC<MessageInputProps> = ({ onSend, onFileUpload, disabled })
           onChange={(e) => setText(e.target.value)}
           onKeyDown={handleKeyDown}
           disabled={disabled}
-          placeholder="Type a message..."
+          placeholder={placeholder}
           rows={1}
           className="flex-1 resize-none border-none bg-transparent text-sm text-[#e8eaed] placeholder-[#71747a] outline-none disabled:opacity-50"
         />

--- a/frontend/src/components/chat/MessageList.tsx
+++ b/frontend/src/components/chat/MessageList.tsx
@@ -24,6 +24,7 @@ const MessageList: FC<MessageListProps> = ({
   const shouldAutoScroll = useRef(true);
   const prevMessageCount = useRef(0);
   const [profilePics, setProfilePics] = useState<Record<string, string>>({});
+  const [displayNames, setDisplayNames] = useState<Record<string, string>>({});
   const fetchedSenders = useRef<Set<string>>(new Set());
   const [hasDoneInitialScroll, setHasDoneInitialScroll] = useState(false);
   const [hideUnreadBoundary, setHideUnreadBoundary] = useState(false);
@@ -56,6 +57,9 @@ const MessageList: FC<MessageListProps> = ({
         .then((data) => {
           if (data?.profile_pic) {
             setProfilePics((prev) => ({ ...prev, [sender]: data.profile_pic }));
+          }
+          if (data?.display_name) {
+            setDisplayNames((prev) => ({ ...prev, [sender]: data.display_name }));
           }
         })
         .catch(() => {});
@@ -165,6 +169,7 @@ const MessageList: FC<MessageListProps> = ({
               isPending={isPending}
               isFailed={isFailed}
               profilePic={profilePics[msg.sender] || undefined}
+              displayName={displayNames[msg.sender]}
             />
           </div>
         );

--- a/frontend/src/hooks/useWebhooks.ts
+++ b/frontend/src/hooks/useWebhooks.ts
@@ -1,0 +1,58 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { api } from '../lib/api';
+
+export interface Webhook {
+  id: string;
+  name: string;
+  url: string;
+  profile_pic?: string;
+  created_at: number;
+  last_used: number | null;
+}
+
+export function useWebhooks() {
+  return useQuery<Webhook[]>({
+    queryKey: ['webhooks'],
+    queryFn: () => api<Webhook[]>('/api/user/webhooks'),
+    refetchOnWindowFocus: false,
+  });
+}
+
+export function useCreateWebhook() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: { name: string; avatar_url?: string }) =>
+      api<Webhook>('/api/user/webhooks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['webhooks'] });
+    },
+  });
+}
+
+export function useDeleteWebhook() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (webhookId: string) =>
+      api(`/api/user/webhooks/${webhookId}`, { method: 'DELETE' }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['webhooks'] });
+    },
+  });
+}
+
+export function useRegenerateWebhook() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (webhookId: string) =>
+      api<{ url: string }>(`/api/user/webhooks/${webhookId}/regenerate`, {
+        method: 'POST',
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['webhooks'] });
+    },
+  });
+}

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -124,7 +124,8 @@ export default function ChatPage() {
             <MessageInput
               onSend={handleSend}
               onFileUpload={handleFileUpload}
-              disabled={uploadFile.isPending}
+              disabled={uploadFile.isPending || activeChatId?.startsWith('webhook-')}
+              isWebhook={activeChatId?.startsWith('webhook-')}
             />
           </>
         )}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { useProfile, useUpdateProfile, useUploadProfilePic, useDeleteProfilePic } from '../hooks/useProfile';
+import { useWebhooks, useCreateWebhook, useDeleteWebhook, useRegenerateWebhook } from '../hooks/useWebhooks';
 import { useLogout } from '../hooks/useAuth';
 import { Avatar, Button, Input, Spinner } from '../components/ui';
 
@@ -7,16 +8,24 @@ const ACCENT_COLORS = ['#6e8efb', '#ff716c', '#e9caf0', '#4d3755', '#28a745'];
 
 export default function SettingsPage() {
   const { data: profile, isLoading } = useProfile();
+  const { data: webhooks = [] } = useWebhooks();
   const updateProfile = useUpdateProfile();
   const uploadPic = useUploadProfilePic();
   const deletePic = useDeleteProfilePic();
   const logout = useLogout();
+  const createWebhook = useCreateWebhook();
+  const deleteWebhook = useDeleteWebhook();
+  const regenerateWebhook = useRegenerateWebhook();
 
   const [displayName, setDisplayName] = useState('');
   const [theme, setTheme] = useState(() => localStorage.getItem('theme') || 'dark');
   const [accentColor, setAccentColor] = useState(() => localStorage.getItem('accent_color') || '#6e8efb');
   const [enableChime, setEnableChime] = useState(() => localStorage.getItem('notif_chime') !== 'false');
   const [enableDesktopNotif, setEnableDesktopNotif] = useState(() => localStorage.getItem('notif_desktop') !== 'false');
+  const [showWebhookDialog, setShowWebhookDialog] = useState(false);
+  const [webhookName, setWebhookName] = useState('');
+  const [webhookAvatarUrl, setWebhookAvatarUrl] = useState('');
+  const [copiedWebhookId, setCopiedWebhookId] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -51,6 +60,26 @@ export default function SettingsPage() {
   const handlePicUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) uploadPic.mutate(file);
+  };
+
+  const handleCreateWebhook = () => {
+    if (!webhookName.trim()) return;
+    createWebhook.mutate({
+      name: webhookName,
+      avatar_url: webhookAvatarUrl || undefined,
+    }, {
+      onSuccess: () => {
+        setWebhookName('');
+        setWebhookAvatarUrl('');
+        setShowWebhookDialog(false);
+      },
+    });
+  };
+
+  const handleCopyWebhook = (url: string, webhookId: string) => {
+    navigator.clipboard.writeText(url);
+    setCopiedWebhookId(webhookId);
+    setTimeout(() => setCopiedWebhookId(null), 2000);
   };
 
   if (isLoading) {
@@ -168,6 +197,102 @@ export default function SettingsPage() {
             <span className="text-sm text-[#e8eaed]">Message chime sound</span>
           </label>
         </div>
+      </section>
+
+      {/* Webhooks Section */}
+      <section className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-medium text-[#71747a] uppercase tracking-wide">Webhooks</h2>
+          <Button
+            onClick={() => setShowWebhookDialog(true)}
+            className="text-xs px-3 py-1.5 bg-[var(--accent)] text-black hover:bg-[var(--accent)]/90"
+          >
+            Create
+          </Button>
+        </div>
+
+        {webhooks.length === 0 ? (
+          <p className="text-sm text-[#71747a]">No webhooks yet. Create one to receive messages via incoming webhooks.</p>
+        ) : (
+          <div className="space-y-3">
+            {webhooks.map((webhook) => (
+              <div key={webhook.id} className="p-4 rounded-lg bg-[#141517] border border-[#232529] space-y-2">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    {webhook.profile_pic && (
+                      <img src={webhook.profile_pic} alt={webhook.name} className="w-8 h-8 rounded-full" />
+                    )}
+                    <span className="text-sm font-medium text-[#e8eaed]">{webhook.name}</span>
+                  </div>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => handleCopyWebhook(webhook.url, webhook.id)}
+                      className="text-xs px-2 py-1 rounded bg-[#232529] text-[#71747a] hover:bg-[#333] transition-colors"
+                    >
+                      {copiedWebhookId === webhook.id ? 'Copied!' : 'Copy URL'}
+                    </button>
+                    <button
+                      onClick={() => regenerateWebhook.mutate(webhook.id)}
+                      className="text-xs px-2 py-1 rounded bg-[#232529] text-[#71747a] hover:bg-[#333] transition-colors"
+                      disabled={regenerateWebhook.isPending}
+                    >
+                      {regenerateWebhook.isPending ? 'Regen...' : 'Regenerate'}
+                    </button>
+                    <button
+                      onClick={() => deleteWebhook.mutate(webhook.id)}
+                      className="text-xs px-2 py-1 rounded bg-[#232529] text-red-400 hover:bg-red-400/20 transition-colors"
+                      disabled={deleteWebhook.isPending}
+                    >
+                      {deleteWebhook.isPending ? 'Deleting...' : 'Delete'}
+                    </button>
+                  </div>
+                </div>
+                <div className="text-xs text-[#71747a] space-y-1">
+                  <div>Created: {new Date(webhook.created_at * 1000).toLocaleDateString()}</div>
+                  {webhook.last_used && <div>Last used: {new Date(webhook.last_used * 1000).toLocaleString()}</div>}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {showWebhookDialog && (
+          <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+            <div className="bg-[#141517] rounded-lg border border-[#232529] p-6 max-w-sm w-full mx-4 space-y-4">
+              <h3 className="text-lg font-semibold text-[#e8eaed]">Create Webhook</h3>
+              <Input
+                placeholder="Webhook name (e.g., GitHub)"
+                value={webhookName}
+                onChange={(e) => setWebhookName(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && handleCreateWebhook()}
+              />
+              <Input
+                placeholder="Avatar URL (optional)"
+                value={webhookAvatarUrl}
+                onChange={(e) => setWebhookAvatarUrl(e.target.value)}
+              />
+              <div className="flex gap-3 justify-end">
+                <Button
+                  onClick={() => {
+                    setShowWebhookDialog(false);
+                    setWebhookName('');
+                    setWebhookAvatarUrl('');
+                  }}
+                  className="bg-transparent border border-[#232529] text-[#e8eaed] hover:bg-[#141517]"
+                >
+                  Cancel
+                </Button>
+                <Button
+                  onClick={handleCreateWebhook}
+                  disabled={createWebhook.isPending || !webhookName.trim()}
+                  className="bg-[var(--accent)] text-black hover:bg-[var(--accent)]/90"
+                >
+                  {createWebhook.isPending ? 'Creating...' : 'Create'}
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
       </section>
 
       {/* Actions */}

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -53,5 +53,6 @@ from routes.users import users_blp                                      # noqa: 
 from routes.chats import chats_blp                                      # noqa: E402
 from routes.uploads import uploads_blp                                  # noqa: E402
 from routes.invites import invites_blp                                  # noqa: E402
+from routes.webhooks import webhooks_blp                                # noqa: E402
 
-ALL_BLUEPRINTS = [auth_blp, users_blp, chats_blp, uploads_blp, invites_blp]
+ALL_BLUEPRINTS = [auth_blp, users_blp, chats_blp, uploads_blp, invites_blp, webhooks_blp]

--- a/routes/chats.py
+++ b/routes/chats.py
@@ -154,6 +154,11 @@ class ChatMessagesResource(MethodView):
         receiver = f"{target}@{DOMAIN}" if "@" not in target else target
         sender = f"{request.user.username}@{DOMAIN}"
 
+        # Block sending to webhooks (one-way only)
+        username = receiver.split("@")[0]
+        if username.startswith("webhook-"):
+            abort(403, message="Cannot send messages to webhooks")
+
         # Verify the recipient exists before saving
         if "#" not in target:
             try:

--- a/routes/chats.py
+++ b/routes/chats.py
@@ -23,7 +23,7 @@ class ChatListResource(MethodView):
     def get(self):
         """List all conversations for the authenticated user"""
         require_auth()
-        from app import Message, DOMAIN
+        from app import Message, DOMAIN, Webhook
         db = current_app.extensions['sqlalchemy']
         me = f"{request.user.username}@{DOMAIN}"
 
@@ -36,19 +36,28 @@ class ChatListResource(MethodView):
         chats = []
 
         for partner in sorted(partners):
-            try:
-                profile = get_profile(partner)
-            except ConnectionError:
-                profile = None
+            display_name = partner.split("@")[0]
+            profile_pic = None
+            status = "offline"
 
-            if profile:
-                display_name = profile["display_name"]
-                profile_pic = profile["profile_pic"]
-                status = profile["status"]
+            webhook = None
+            if partner.endswith(f"@{DOMAIN}") and partner.startswith("webhook-"):
+                webhook_id = partner.split("@")[0][8:]  # Remove "webhook-" prefix
+                webhook = db.session.query(Webhook).filter_by(id=webhook_id, user_id=request.user.id).first()
+
+            if webhook:
+                display_name = webhook.name
+                profile_pic = webhook.profile_pic
             else:
-                display_name = partner.split("@")[0]
-                profile_pic = None
-                status = "offline"
+                try:
+                    profile = get_profile(partner)
+                except ConnectionError:
+                    profile = None
+
+                if profile:
+                    display_name = profile["display_name"]
+                    profile_pic = profile["profile_pic"]
+                    status = profile["status"]
 
             unread_count = db.session.query(Message).filter(
                 Message.sender == partner,

--- a/routes/users.py
+++ b/routes/users.py
@@ -175,9 +175,26 @@ class ProfilePictureResource(MethodView):
 class UserProfileResource(MethodView):
     @users_blp.response(200, UserProfile)
     def get(self, full_id):
-        """Get a user's profile by username@domain (federation-aware)"""
+        """Get a user's profile by username@domain (federation-aware, webhook-aware)"""
         if "@" not in full_id:
             abort(400, message="Invalid format. Use username@domain")
+
+        from app import DOMAIN, Webhook
+        db = current_app.extensions['sqlalchemy']
+        username, domain = full_id.rsplit("@", 1)
+
+        # Check if it's a webhook sender on the local domain
+        if domain == DOMAIN and username.startswith("webhook-"):
+            webhook_id = username[8:]  # Remove "webhook-" prefix
+            webhook = db.session.query(Webhook).filter_by(id=webhook_id).first()
+            if webhook:
+                return {
+                    "username": full_id,
+                    "display_name": webhook.name,
+                    "profile_pic": webhook.profile_pic,
+                    "status": "offline",
+                    "is_admin": False,
+                }
 
         try:
             profile = get_profile(full_id)

--- a/routes/webhooks.py
+++ b/routes/webhooks.py
@@ -1,0 +1,107 @@
+"""Webhook management routes — /api/user/webhooks"""
+from flask.views import MethodView
+from flask_smorest import Blueprint as SmorestBlueprint, abort
+from flask import request, current_app
+from datetime import datetime
+import uuid
+import secrets
+
+from schemas import WebhookObject, WebhookCreateRequest, WebhookRegenerateResponse, WebhookPayload
+from routes import require_auth
+
+
+webhooks_blp = SmorestBlueprint("webhooks", __name__, url_prefix="/api/user/webhooks",
+                                description="Personal webhook management")
+
+
+# ── / (list & create webhooks) ────────────────────────────────────────────
+
+@webhooks_blp.route("/")
+class WebhookListResource(MethodView):
+    @webhooks_blp.response(200, WebhookObject(many=True))
+    def get(self):
+        """List user's webhooks"""
+        require_auth()
+        from app import Webhook, DOMAIN
+        db = current_app.extensions['sqlalchemy']
+
+        webhooks = db.session.query(Webhook).filter_by(user_id=request.user.id).all()
+
+        return [_serialize_webhook(w, DOMAIN) for w in webhooks]
+
+    @webhooks_blp.arguments(WebhookCreateRequest)
+    @webhooks_blp.response(201, WebhookObject)
+    def post(self, data):
+        """Create new webhook. Name is immutable and used as message sender identity."""
+        require_auth()
+        from app import Webhook, DOMAIN
+        db = current_app.extensions['sqlalchemy']
+
+        webhook = Webhook(
+            user_id=request.user.id,
+            name=data["name"],
+            token=secrets.token_urlsafe(32),
+            profile_pic=data.get("avatar_url"),
+        )
+        db.session.add(webhook)
+        db.session.commit()
+
+        return _serialize_webhook(webhook, DOMAIN)
+
+
+# ── /{webhook_id} (delete webhook) ────────────────────────────────────────
+
+@webhooks_blp.route("/<webhook_id>")
+class WebhookDetailResource(MethodView):
+    @webhooks_blp.response(204)
+    def delete(self, webhook_id):
+        """Delete a webhook"""
+        require_auth()
+        from app import Webhook
+        db = current_app.extensions['sqlalchemy']
+
+        webhook = db.session.query(Webhook).filter_by(id=webhook_id, user_id=request.user.id).first()
+        if not webhook:
+            abort(404, message="Webhook not found")
+
+        db.session.delete(webhook)
+        db.session.commit()
+        return None
+
+
+# ── /{webhook_id}/regenerate ────────────────────────────────────────────────
+
+@webhooks_blp.route("/<webhook_id>/regenerate", methods=["POST"])
+class WebhookRegenerateResource(MethodView):
+    @webhooks_blp.response(200, WebhookRegenerateResponse)
+    def post(self, webhook_id):
+        """Regenerate webhook token"""
+        require_auth()
+        from app import Webhook, DOMAIN
+        db = current_app.extensions['sqlalchemy']
+
+        webhook = db.session.query(Webhook).filter_by(id=webhook_id, user_id=request.user.id).first()
+        if not webhook:
+            abort(404, message="Webhook not found")
+
+        webhook.token = secrets.token_urlsafe(32)
+        db.session.commit()
+
+        return {"url": _get_webhook_url(webhook, DOMAIN)}
+
+
+def _serialize_webhook(webhook, domain):
+    """Convert Webhook model to response dict."""
+    return {
+        "id": webhook.id,
+        "name": webhook.name,
+        "url": _get_webhook_url(webhook, domain),
+        "profile_pic": webhook.profile_pic,
+        "created_at": webhook.created_at.timestamp(),
+        "last_used": webhook.last_used.timestamp() if webhook.last_used else None,
+    }
+
+
+def _get_webhook_url(webhook, domain):
+    """Generate full webhook URL."""
+    return f"http://{domain}/webhooks/{webhook.id}/{webhook.token}"

--- a/schemas.py
+++ b/schemas.py
@@ -166,6 +166,38 @@ class UploadResponse(Schema):
 
 
 # ---------------------------------------------------------------------------
+# Webhook Schemas
+# ---------------------------------------------------------------------------
+
+class WebhookObject(Schema):
+    """Webhook representation."""
+    id = fields.String(dump_only=True, metadata={"description": "Webhook ID"})
+    name = fields.String(metadata={"description": "Webhook name"})
+    url = fields.String(dump_only=True, metadata={"description": "Full webhook URL for posting"})
+    profile_pic = fields.String(allow_none=True, metadata={"description": "Avatar URL for webhook messages"})
+    created_at = fields.Float(dump_only=True, metadata={"description": "Creation timestamp"})
+    last_used = fields.Float(dump_only=True, allow_none=True, metadata={"description": "Last usage timestamp"})
+
+
+class WebhookCreateRequest(Schema):
+    """Request to create a webhook."""
+    name = fields.String(required=True, metadata={"description": "Webhook name"})
+    avatar_url = fields.String(load_default=None, metadata={"description": "Avatar URL for webhook messages"})
+
+
+class WebhookRegenerateResponse(Schema):
+    """Response after regenerating webhook token."""
+    url = fields.String(metadata={"description": "New full webhook URL"})
+
+
+class WebhookPayload(Schema):
+    """Incoming webhook payload."""
+    content = fields.String(required=True, metadata={"description": "Message content"})
+    username = fields.String(load_default=None, metadata={"description": "Override sender display name"})
+    avatar_url = fields.String(load_default=None, metadata={"description": "Override sender avatar URL"})
+
+
+# ---------------------------------------------------------------------------
 # Admin Schemas
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
- Personal webhooks: users create endpoints to receive messages as DMs
- Channel webhooks: channels receive webhook-posted messages
- Immutable webhook names, stable identity via webhook ID
- Avatar support for webhook messages
- Settings UI to create, copy URL, regenerate token, delete webhooks
- Webhook profile pics display in chat with short names for all names instead of domain
- Both user server and channel server support (channel server not tested)


implements #12 